### PR TITLE
the _config.yml file, the 'gems' configuration option has been rename…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ sections: [
     ['post', 'Posts']
 ]
 
-gems:
+plugins:
     - jekyll-paginate
 
 


### PR DESCRIPTION
…d to 'plugins' as 'gems' is deprecated